### PR TITLE
Add NAS identifier to messages published to redis channel

### DIFF
--- a/accel-pppd/redis/redis.c
+++ b/accel-pppd/redis/redis.c
@@ -505,7 +505,7 @@ static void ap_redis_enqueue(struct ap_session *ses, const int event)
 		msg->ctrl_ifname = _strdup(ses->ctrl->ifname);
 
     	msg->ip_addr = _strdup(tmp_addr);
-	msg->nas_identifier = ap_redis->nas_id;
+	msg->nas_identifier = _strdup(ap_redis->nas_id);
 
 	switch(ses->ctrl->type) {
 	case CTRL_TYPE_PPTP:    msg->ses_ctrl_type = REDIS_SES_CTRL_TYPE_PPTP;    break;

--- a/accel-pppd/redis/redis.c
+++ b/accel-pppd/redis/redis.c
@@ -250,6 +250,8 @@ static void ap_redis_dequeue(struct ap_redis_t* ap_redis, redisContext* ctx)
 			free(msg->ip_addr);
 		if (msg->ctrl_ifname)
 			free(msg->ctrl_ifname);
+		if (msg->nas_identifier)
+			free(msg->nas_identifier);
 
 		mempool_free(msg);
 	}

--- a/accel-pppd/redis/redis.c
+++ b/accel-pppd/redis/redis.c
@@ -85,6 +85,7 @@ struct ap_redis_msg_t {
 	char* sessionid;
 	int pppoe_sessionid;
 	char* ctrl_ifname;
+	char* nas_identifier;
 };
 
 struct ap_redis_t {
@@ -208,13 +209,18 @@ static void ap_redis_dequeue(struct ap_redis_t* ap_redis, redisContext* ctx)
 		if (msg->ip_addr)
 			json_object_object_add(jobj, "ip_addr", json_object_new_string(msg->ip_addr));
 
-          /* pppoe_sessionid */
+          	/* pppoe_sessionid */
 		if (msg->pppoe_sessionid)
 			json_object_object_add(jobj, "pppoe_sessionid", json_object_new_int(msg->pppoe_sessionid));
 
 		/* ctrl_ifname */
 		if (msg->ctrl_ifname)
 			json_object_object_add(jobj, "ctrl_ifname", json_object_new_string(msg->ctrl_ifname));
+
+                /* nas_identifier */
+                if (msg->nas_identifier)
+                        json_object_object_add(jobj, "nas_identifier", json_object_new_string(msg->nas_identifier));
+
 
           // TODO: send msg to redis instance
 		redisReply* reply;


### PR DESCRIPTION
Added the "nas_identifier" field to the messages published to the redis channel. This value is read from the accel-ppp configuration file under the [radius] section. If this value is not set, the default nas_identifier "accel-ppp"  is used instead.