### PR TITLE
Fix high cpu usage in redis module

### DIFF
--- a/accel-pppd/redis/redis.c
+++ b/accel-pppd/redis/redis.c
@@ -316,6 +316,16 @@ static void* ap_redis_thread(void* arg)
 			continue;
 		}
 
+		uint64_t num = 0;
+		ssize_t bytes_read;
+
+		if ((bytes_read = read(epev[0].data.fd, &num, sizeof(uint64_t))) == -1){
+			log_error("ap_redis: Could not read epoll fd: %d (%s)\n", errno, strerror(errno));
+			continue;
+		}
+
+		log_debug("ap_redis: Epoll fd content: %lu.\n", num);
+
 		for (unsigned int i = 0; i < 32; i++) {
 			if (epev[i].data.fd == ap_redis->evfd) {
 				ap_redis_dequeue(ap_redis, ctx);

--- a/accel-pppd/redis/redis.c
+++ b/accel-pppd/redis/redis.c
@@ -319,7 +319,7 @@ static void* ap_redis_thread(void* arg)
 		uint64_t num = 0;
 		ssize_t bytes_read;
 
-		if ((bytes_read = read(epev[0].data.fd, &num, sizeof(uint64_t))) == -1){
+		if ((bytes_read = read(epev[0].data.fd, &num, sizeof(uint64_t))) < 0){
 			log_error("ap_redis: Could not read epoll fd: %d (%s)\n", errno, strerror(errno));
 			continue;
 		}


### PR DESCRIPTION
https://github.com/dpdk-vbng-cp/docker-accel-ppp/issues/19

High CPU usage was observer on the redis event worker after the first
arrival of an event. We traced down the issue to the `epoll_pwait` call.
The epoll file descriptor was not flushed after wakeup resulting in the
worker not going back into the loop waiting for new events. By reading
from the file descriptor after wakeup the eventfd gets cleared.