### PR TITLE
Fix event handling in redis module

### DIFF
--- a/accel-pppd/ctrl/pppoe/pppoe.c
+++ b/accel-pppd/ctrl/pppoe/pppoe.c
@@ -407,7 +407,7 @@ static struct pppoe_conn_t *allocate_channel(struct pppoe_serv_t *serv, const ui
 	conn->ppp.ses.net = serv->net;
 	conn->ppp.ses.ctrl = &conn->ctrl;
 	conn->ppp.ses.chan_name = conn->ctrl.calling_station_id;
-     conn->ppp.ses.conn_pppoe_sid = conn->sid;
+	conn->ppp.ses.conn_pppoe_sid = conn->sid;
 
 	if (conf_ip_pool)
 		conn->ppp.ses.ipv4_pool_name = _strdup(conf_ip_pool);

--- a/accel-pppd/include/ap_session.h
+++ b/accel-pppd/include/ap_session.h
@@ -118,7 +118,7 @@ struct ap_session
 	uint32_t acct_rx_bytes_i;
 	uint32_t acct_tx_bytes_i;
 	int acct_start;
-     int conn_pppoe_sid;
+	int conn_pppoe_sid;
 };
 
 struct ap_session_stat

--- a/accel-pppd/redis/redis.c
+++ b/accel-pppd/redis/redis.c
@@ -599,9 +599,9 @@ static void ev_ses_pre_finished(struct ap_session *ses)
 	ap_redis_enqueue(ses, REDIS_EV_SES_PRE_FINISHED);
 }
 
-static void ev_radius_access_accept(struct ap_session *ses)
+static void ev_radius_access_accept(struct ev_radius_t *ev)
 {
-	ap_redis_enqueue(ses, REDIS_EV_RADIUS_ACCESS_ACCEPT);
+	ap_redis_enqueue(ev->ses, REDIS_EV_RADIUS_ACCESS_ACCEPT);
 }
 
 static void ev_radius_coa(struct ap_session *ses)

--- a/accel-pppd/redis/redis.c
+++ b/accel-pppd/redis/redis.c
@@ -589,9 +589,9 @@ static void ev_ses_acct_start(struct ap_session *ses)
 	ap_redis_enqueue(ses, REDIS_EV_SES_ACCT_START);
 }
 
-static void ev_ses_auth_failed(struct ap_session *ses)
+static void ev_ses_auth_failed(struct ppp_t *ppp)
 {
-	ap_redis_enqueue(ses, REDIS_EV_SES_AUTH_FAILED);
+	ap_redis_enqueue(&ppp->ses, REDIS_EV_SES_AUTH_FAILED);
 }
 
 static void ev_ses_pre_finished(struct ap_session *ses)

--- a/accel-pppd/redis/redis.c
+++ b/accel-pppd/redis/redis.c
@@ -604,9 +604,9 @@ static void ev_radius_access_accept(struct ev_radius_t *ev)
 	ap_redis_enqueue(ev->ses, REDIS_EV_RADIUS_ACCESS_ACCEPT);
 }
 
-static void ev_radius_coa(struct ap_session *ses)
+static void ev_radius_coa(struct ev_radius_t *ev)
 {
-	ap_redis_enqueue(ses, REDIS_EV_RADIUS_COA);
+	ap_redis_enqueue(ev->ses, REDIS_EV_RADIUS_COA);
 }
 
 

--- a/accel-pppd/redis/redis.c
+++ b/accel-pppd/redis/redis.c
@@ -455,32 +455,32 @@ static void ap_redis_enqueue(struct ap_session *ses, const int event)
 	}
 
 	switch (event) {
-	case REDIS_EV_SES_STARTING:
-	case REDIS_EV_SES_STARTED:
-	case REDIS_EV_SES_FINISHING:
-	case REDIS_EV_SES_FINISHED:
-	case REDIS_EV_SES_AUTHORIZED:
-	case REDIS_EV_CTRL_STARTING:
-	case REDIS_EV_CTRL_STARTED:
-	case REDIS_EV_CTRL_FINISHED:
-	case REDIS_EV_SES_PRE_UP:
-	case REDIS_EV_SES_ACCT_START:
-	case REDIS_EV_CONFIG_RELOAD:
-	case REDIS_EV_SES_AUTH_FAILED:
-	case REDIS_EV_SES_PRE_FINISHED:
-	case REDIS_EV_IP_CHANGED:
-	case REDIS_EV_SHAPER:
-	case REDIS_EV_MPPE_KEYS:
-	case REDIS_EV_DNS:
-	case REDIS_EV_WINS:
-	case REDIS_EV_FORCE_INTERIM_UPDATE:
-	case REDIS_EV_RADIUS_ACCESS_ACCEPT:
-	case REDIS_EV_RADIUS_COA: {
-		/* do nothing */
-	} break;
-	default: {
-		return;
-	};
+		case REDIS_EV_SES_STARTING:
+		case REDIS_EV_SES_STARTED:
+		case REDIS_EV_SES_FINISHING:
+		case REDIS_EV_SES_FINISHED:
+		case REDIS_EV_SES_AUTHORIZED:
+		case REDIS_EV_CTRL_STARTING:
+		case REDIS_EV_CTRL_STARTED:
+		case REDIS_EV_CTRL_FINISHED:
+		case REDIS_EV_SES_PRE_UP:
+		case REDIS_EV_SES_ACCT_START:
+		case REDIS_EV_CONFIG_RELOAD:
+		case REDIS_EV_SES_AUTH_FAILED:
+		case REDIS_EV_SES_PRE_FINISHED:
+		case REDIS_EV_IP_CHANGED:
+		case REDIS_EV_SHAPER:
+		case REDIS_EV_MPPE_KEYS:
+		case REDIS_EV_DNS:
+		case REDIS_EV_WINS:
+		case REDIS_EV_FORCE_INTERIM_UPDATE:
+		case REDIS_EV_RADIUS_ACCESS_ACCEPT:
+		case REDIS_EV_RADIUS_COA: {
+			/* do nothing */
+		} break;
+		default: {
+			return;
+		};
 	}
 
 	struct ap_redis_msg_t* msg = mempool_alloc(ap_redis->msg_pool);


### PR DESCRIPTION
# Description
Accel-ppp is not consistent with the parameter passed to the different triton events. This PR fixes the event handling of the events in which the passed parameter differs from the usually passed `ap_session` struct pointer.

Fixes also some formatting issues that have been found during the bug fixing.

# Test instructions
## Fix for `EV_RADIUS_ACCESS_ACCEPT` event handling (8fdbe10f0620f56d588f7635cc7d6f46c7198683)
### Requirements
- An accel-ppp instance connected to a running redis-server
- `redis-cli`
- `accel-ppp.conf` with `redis` module enabled and a config similar to the following (with **ev_radius_access_accept=yes** enabled):
    ```
    ...
    redis
    ...
    [redis]
    host=redis
    port=6379
    pubchan=accel-ppp

    # select the event types to emit a message via redis
    ev_ses_starting=yes
    ev_ses_finishing=yes
    ev_ses_finished=yes
    ev_ses_pre_finished=yes
    ev_ses_acct_start=yes
    ev_radius_access_accept=yes
    ```
    
### Test steps
1. Connect `redis-cli` to the running redis instance and subscribe to the `accel-ppp` channel:
    ```
    $ redis-cli 
        127.0.0.1:6379> SUBSCRIBE accel-ppp
        Reading messages... (press Ctrl-C to quit)
        1) "subscribe"
        2) "accel-ppp"
        3) (integer) 1

    ```
2. Create a client session with a valid username and password:
    ```
    $ pppd pty "pppoe -I <IFACE> -T 80 -U -m 1350" \
        noccp \
        ipparam <IFACE> \
        linkname <IFACE> \
        noipdefault \
        noauth \
        default-asyncmap \
        defaultroute \
        hide-password \
        updetach \
        mtu 1350 \
        mru 1350 \
        noaccomp \
        nodeflate \
        nopcomp \
        novj \
        novjccomp \
        lcp-echo-interval 40 \
        lcp-echo-failure 3 \
        user <PPP_USER> \
        password <PPP_PASWORD>
    ```

### Expected behavior
You should see a message from the `radius-access-accept` event published to redis:
```
127.0.0.1:6379> SUBSCRIBE accel-ppp
Reading messages... (press Ctrl-C to quit)
...
1) "message"
2) "accel-ppp"
3) "{ \"event\": \"radius-access-accept\", \"ctrl_type\": \"pppoe\", \"channel_name\": \"aa:aa:aa:aa:00:c8\", \"session_id\": \"d89da8604fc10e66\", \"called_station_id\": \"06:9d:98:10:37:7e\", \"calling_station_id\": \"aa:aa:aa:aa:00:c8\", \"name\": \"pppoe\", \"ip_addr\": \"\", \"pppoe_sessionid\": 1, \"ctrl_ifname\": \"vethAC.7.200\", \"nas_identifier\": \"nas1\"}"
...
```

## Fix for `EV_SES_AUTH_FAILED` event handling (8fdbe10f0620f56d588f7635cc7d6f46c7198683)
### Requirements
- An accel-ppp instance connected to a running redis-server
- `redis-cli`
- `accel-ppp.conf` with `redis` module enabled and a config similar to the following (with **ev_ses_auth_failed=yes** enabled):
    ```
    ...
    redis
    ...
    [redis]
    host=redis
    port=6379
    pubchan=accel-ppp

    # select the event types to emit a message via redis
    ev_ses_starting=yes
    ev_ses_finishing=yes
    ev_ses_finished=yes
    ev_ses_pre_finished=yes
    ev_ses_acct_start=yes
    ev_ses_auth_failed=yes
    ```
    
### Test steps
1. Connect `redis-cli` to the running redis instance and subscribe to the `accel-ppp` channel:
    ```
    $ redis-cli 
        127.0.0.1:6379> SUBSCRIBE accel-ppp
        Reading messages... (press Ctrl-C to quit)
        1) "subscribe"
        2) "accel-ppp"
        3) (integer) 1

    ```
2. Create a client session with a random username and password:
    ```
    $ pppd pty "pppoe -I <IFACE> -T 80 -U -m 1350" \
        noccp \
        ipparam <IFACE> \
        linkname <IFACE> \
        noipdefault \
        noauth \
        default-asyncmap \
        defaultroute \
        hide-password \
        updetach \
        mtu 1350 \
        mru 1350 \
        noaccomp \
        nodeflate \
        nopcomp \
        novj \
        novjccomp \
        lcp-echo-interval 40 \
        lcp-echo-failure 3 \
        user john \
        password doe
    ```

### Expected behavior
You should see a message from the `session-auth-failed` event published to redis:
```
127.0.0.1:6379> SUBSCRIBE accel-ppp
Reading messages... (press Ctrl-C to quit)
...
1) "message"
2) "accel-ppp"
3) "{ \"event\": \"session-auth-failed\", \"ctrl_type\": \"pppoe\", \"channel_name\": \"aa:aa:aa:aa:00:64\", \"session_id\": \"d89da8604fc1124f\", \"called_station_id\": \"a2:af:43:d0:24:07\", \"calling_station_id\": \"aa:aa:aa:aa:00:64\", \"name\": \"pppoe\", \"username\": \"foo\", \"ip_addr\": \"\", \"pppoe_sessionid\": 1, \"ctrl_ifname\": \"vethAC.7.100\", \"nas_identifier\": \"nas1\" }"
...
```

## Fix for `EV_RADIUS_COA` event handling (5a7cbbbd35f0bc24265e8f361d8fc0e3c7979f0b)
### Requirements
- An accel-ppp instance connected to a running redis-server
- `redis-cli`
- `radclient`
- `accel-ppp.conf` with `redis` module enabled and a config similar to the following (with **ev_radius_coa=yes** and `dae-server` enabled):
    ```
    ...
    redis
    ...
    [radius]
    gw-ip-address=192.51.0.1
    #nas-ip-address=127.0.0.1
    nas-port=ifname
    nas-identifier=nas1
    server=172.16.101.29,SECRET,auth-port=1812,acct-port=1813,req-limit=50,fail-timeout=0,max-fail=10,weight=1
    dae-server=127.0.0.1:3799,secret

    ...
    [redis]
    host=redis
    port=6379
    pubchan=accel-ppp

    # select the event types to emit a message via redis
    ev_ses_starting=yes
    ev_ses_finishing=yes
    ev_ses_finished=yes
    ev_ses_pre_finished=yes
    ev_ses_acct_start=yes
    ev_ses_auth_failed=yes
    ```
    
### Test steps
1. Connect `redis-cli` to the running redis instance and subscribe to the `accel-ppp` channel:
    ```
    $ redis-cli 
        127.0.0.1:6379> SUBSCRIBE accel-ppp
        Reading messages... (press Ctrl-C to quit)
        1) "subscribe"
        2) "accel-ppp"
        3) (integer) 1

    ```
2. Create a client session:
    ```
    $ pppd pty "pppoe -I <IFACE> -T 80 -U -m 1350" \
        noccp \
        ipparam <IFACE> \
        linkname <IFACE> \
        noipdefault \
        noauth \
        default-asyncmap \
        defaultroute \
        hide-password \
        updetach \
        mtu 1350 \
        mru 1350 \
        noaccomp \
        nodeflate \
        nopcomp \
        novj \
        novjccomp \
        lcp-echo-interval 40 \
        lcp-echo-failure 3 \
        user <PPP_USER> \
        password <PPP_PASWORD>
    ```
3. Identify parameters (`User-Name`, `Acct-Session-Id`, `NAS-Port-Id`, `,Framed-IP-Address`, `Calling-Station-Id`) for the CoA request from the redis messages:
    ```
    127.0.0.1:6379> SUBSCRIBE accel-ppp
        Reading messages... (press Ctrl-C to quit)
        ...
        1) "message"
        2) "accel-ppp"
        3) "{ \"event\": \"session-starting\", \"ctrl_type\": \"pppoe\", \"channel_name\": \"aa:aa:aa:aa:00:64\", \"session_id\": 
        \"d89da8604fc11250\", \"called_station_id\": \"a2:af:43:d0:24:07\", \"calling_station_id\": \"aa:aa:aa:aa:00:64\", \"name\": 
        \"pppoe\", \"ip_addr\": \"\", \"pppoe_sessionid\": 64, \"ctrl_ifname\": \"vethAC.7.100\", \"nas_identifier\": \"nas1\" }"
        1) "message"
        2) "accel-ppp"
        3) "{ \"event\": \"radius-access-accept\", \"ctrl_type\": \"pppoe\", \"channel_name\": \"aa:aa:aa:aa:00:64\", \"session_id\": 
        \"d89da8604fc11250\", \"called_station_id\": \"a2:af:43:d0:24:07\", \"calling_station_id\": \"aa:aa:aa:aa:00:64\", \"name\": 
        \"pppoe\", \"ip_addr\": \"\", \"pppoe_sessionid\": 64, \"ctrl_ifname\": \"vethAC.7.100\", \"nas_identifier\": \"nas1\", \"qos_val\": 
        \"1\\/16000\\/2000\" }"
        1) "message"
        2) "accel-ppp"
        3) "{ \"event\": \"session-acct-start\", \"ctrl_type\": \"pppoe\", \"channel_name\": \"aa:aa:aa:aa:00:64\", \"session_id\": 
        \"d89da8604fc11250\", \"called_station_id\": \"a2:af:43:d0:24:07\", \"calling_station_id\": \"aa:aa:aa:aa:00:64\", \"name\": 
        \"pppoe\", \"username\": \"sp-tin\", \"ip_addr\": \"192.51.0.4\", \"pppoe_sessionid\": 64, \"ctrl_ifname\": \"vethAC.7.100\", 
        \"nas_identifier\": \"nas1\", \"qos_val\": \"1\\/16000\\/2000\" }"
    ```
4. Send a CoA request:
    ```
    $  echo "User-Name=sp-tin,Acct-Session-Id=d89da8604fc11250,NAS-Port=0,NAS-Port-Id=ppp0,Framed-IP-Address=192.51.0.4,Calling-Station-Id=aa:aa:aa:aa:00:64" | radclient -x 127.0.0.1:3799 coa SECRET
    ```

### Expected behavior
When you get a CoA ACK,
```
echo "User-Name=sp-tin,Acct-Session-Id=d89da8604fc11250,NAS-Port=0,NAS-Port-Id=ppp0,Framed-IP-Address=192.51.0.4,Calling-Station-Id=aa:aa:aa:aa:00:64" | ra
dclient -x 127.0.0.1:3799 coa secret
Sent CoA-Request Id 182 from 0.0.0.0:42511 to 127.0.0.1:3799 length 83
        User-Name = "sp-tin"
        Acct-Session-Id = "d89da8604fc11250"
        NAS-Port = 0
        NAS-Port-Id = "ppp0"
        Framed-IP-Address = 192.51.0.4
        Calling-Station-Id = "aa:aa:aa:aa:00:64"
Received CoA-ACK Id 182 from 127.0.0.1:3799 to 0.0.0.0:0 length 20
```
you should see a `coa` event message published to the channel:
```
127.0.0.1:6379> SUBSCRIBE accel-ppp
Reading messages... (press Ctrl-C to quit)
1) "subscribe"
2) "accel-ppp"
3) (integer) 1
...
1) "message"
2) "accel-ppp"
3) "{ \"event\": \"coa\", \"ctrl_type\": \"pppoe\", \"channel_name\": \"aa:aa:aa:aa:00:64\", \"session_id\": \"d89da8604fc11250\", \"called_station_id\": \"a2:af:43:d0:24:07\", \"calling_station_id\": \"aa:aa:aa:aa:00:64\", \"name\": \"pppoe\", \"username\": \"sp-tin\", \"ip_addr\": \"192.51.0.4\", \"pppoe_sessionid\": 64, \"ctrl_ifname\": \"vethAC.7.100\", \"nas_identifier\": \"nas1\", \"qos_val\": \"1\\/16000\\/2000\" }"
```