### PR TITLE
[redis] Publish Filter-Id value on redis

### DIFF
--- a/accel-pppd/ctrl/pppoe/pppoe.c
+++ b/accel-pppd/ctrl/pppoe/pppoe.c
@@ -407,6 +407,8 @@ static struct pppoe_conn_t *allocate_channel(struct pppoe_serv_t *serv, const ui
 	conn->ppp.ses.net = serv->net;
 	conn->ppp.ses.ctrl = &conn->ctrl;
 	conn->ppp.ses.chan_name = conn->ctrl.calling_station_id;
+    /* Insert session id into ap_session to make it available for publication
+     * on redis. */
 	conn->ppp.ses.conn_pppoe_sid = conn->sid;
 
 	if (conf_ip_pool)

--- a/accel-pppd/include/ap_session.h
+++ b/accel-pppd/include/ap_session.h
@@ -119,6 +119,7 @@ struct ap_session
 	uint32_t acct_tx_bytes_i;
 	int acct_start;
 	int conn_pppoe_sid;
+	char *filter_id;
 };
 
 struct ap_session_stat

--- a/accel-pppd/include/ap_session.h
+++ b/accel-pppd/include/ap_session.h
@@ -118,6 +118,9 @@ struct ap_session
 	uint32_t acct_rx_bytes_i;
 	uint32_t acct_tx_bytes_i;
 	int acct_start;
+
+    /* Add members for PPPoE session id and Filter-Id to make them available
+     * across events for publication on the redis bus. */
 	int conn_pppoe_sid;
 	char *filter_id;
 };

--- a/accel-pppd/radius/radius.c
+++ b/accel-pppd/radius/radius.c
@@ -384,6 +384,13 @@ int rad_proc_attrs(struct rad_req_t *req)
 			case Framed_IPv6_Route:
 				rad_add_framed_ipv6_route(attr->val.string, rpd);
 				break;
+			case Filter_Id:
+				if (rpd->ses->filter_id)
+					_free(rpd->ses->filter_id);
+				rpd->ses->filter_id = _malloc(attr->len + 1);
+				memcpy(rpd->ses->filter_id, attr->val.string, attr->len);
+				rpd->ses->filter_id[attr->len] = 0;
+				break;
 		}
 	}
 

--- a/accel-pppd/redis/redis.c
+++ b/accel-pppd/redis/redis.c
@@ -87,6 +87,7 @@ struct ap_redis_msg_t {
 	int pppoe_sessionid;
 	char* ctrl_ifname;
 	char* nas_identifier;
+	char* qos_val;
 };
 
 struct ap_redis_t {
@@ -224,6 +225,9 @@ static void ap_redis_dequeue(struct ap_redis_t* ap_redis, redisContext* ctx)
 		if (msg->nas_identifier)
 			json_object_object_add(jobj, "nas_identifier", json_object_new_string(msg->nas_identifier));
 
+		/* qos_val */
+		if (msg->qos_val)
+			json_object_object_add(jobj, "qos_val", json_object_new_string(msg->qos_val));
 
 		// TODO: send msg to redis instance
 		redisReply* reply;
@@ -255,6 +259,8 @@ static void ap_redis_dequeue(struct ap_redis_t* ap_redis, redisContext* ctx)
 			free(msg->ctrl_ifname);
 		if (msg->nas_identifier)
 			free(msg->nas_identifier);
+		if (msg->qos_val)
+			free(msg->qos_val);
 
 		mempool_free(msg);
 	}
@@ -513,6 +519,8 @@ static void ap_redis_enqueue(struct ap_session *ses, const int event)
 		msg->pppoe_sessionid = ses->conn_pppoe_sid;
 	if (ses->ctrl->ifname)
 		msg->ctrl_ifname = _strdup(ses->ctrl->ifname);
+	if (ses->filter_id)
+		msg->qos_val = _strdup(ses->filter_id);
 
 	msg->ip_addr = _strdup(tmp_addr);
 	msg->nas_identifier = _strdup(ap_redis->nas_id);

--- a/accel-pppd/session.c
+++ b/accel-pppd/session.c
@@ -246,6 +246,10 @@ void __export ap_session_finished(struct ap_session *ses)
 	if (ses->timer.tpd)
 		triton_timer_del(&ses->timer);
 
+	if (ses->filter_id)
+		_free(ses->filter_id);
+		ses->filter_id = NULL;
+
 #ifdef USE_BACKUP
 	if (ses->backup)
 		ses->backup->storage->free(ses->backup);


### PR DESCRIPTION
# Description
This PR allows to pass "QoS profiles" to accel-ppp via `Filter-Id` attributes in radius *Access-Accept* messages. The value of `Filter-Id` is stored in accel-ppp's internal session struct and sent as `qos_val` attribute of the JOSN messages published on the redis bus.
# Test instructions
## Publishing `Filter-Id` values to redis

### Requirements
- Radius setup with `Filter-Id` Attributes returned on *Access-Accept* e.g. by adding `Filter-Id` entries to the `radreply` table for freeradius with `rlm_sql` (https://wiki.freeradius.org/guide/SQL-HOWTO-for-freeradius-3.x-on-Debian-Ubuntu#populating-sql)
- An accel-ppp instance connected to a running redis-server
- `redis-cli`
- `accel-ppp.conf` with `redis` module enabled and a config similar to the following (with **ev_radius_access_accept=yes** enabled):
    ```
    ...
    redis
    ...
    [redis]
    host=redis
    port=6379
    pubchan=accel-ppp

    # select the event types to emit a message via redis
    ev_ses_pre_finished=yes
    ev_ses_acct_start=yes
    ev_radius_access_accept=yes
    ```
  
### Test steps
1. Connect `redis-cli` to the running redis instance and subscribe to the `accel-ppp` channel:
    ```
    $ redis-cli 
        127.0.0.1:6379> SUBSCRIBE accel-ppp
        Reading messages... (press Ctrl-C to quit)
        1) "subscribe"
        2) "accel-ppp"
        3) (integer) 1

    ```
2. Create a client session with a user that has a `Filter-Id`:
    ```
    $ pppd pty "pppoe -I <IFACE> -T 80 -U -m 1350" \
        noccp \
        ipparam <IFACE> \
        linkname <IFACE> \
        noipdefault \
        noauth \
        default-asyncmap \
        defaultroute \
        hide-password \
        updetach \
        mtu 1350 \
        mru 1350 \
        noaccomp \
        nodeflate \
        nopcomp \
        novj \
        novjccomp \
        lcp-echo-interval 40 \
        lcp-echo-failure 3 \
        user <PPP_USER> \
        password <PPP_PASWORD>
    ```

### Expected behavior
The `Filter-Id` should be published in the messages on the `accel-ppp` channel as `qos_val`:

```
127.0.0.1:6379> SUBSCRIBE accel-ppp
Reading messages... (press Ctrl-C to quit)
1) "subscribe"
2) "accel-ppp"
3) (integer) 1
1) "message"
2) "accel-ppp"
3) "{ \"event\": \"radius-access-accept\", \"ctrl_type\": \"pppoe\", \"channel_name\": \"aa:aa:aa:aa:00:c8\", \"session_id\": \"d89da8604fc10e66\", \"called_station_id\": \"06:9d:98:10:37:7e\", \"calling_station_id\": \"aa:aa:aa:aa:00:c8\", \"name\": \"pppoe\", \"ip_addr\": \"\", \"pppoe_sessionid\": 1, \"ctrl_ifname\": \"vethAC.7.200\", \"nas_identifier\": \"nas1\", \"qos_val\": \"1\\/16000\\/2000\" }"
1) "message"
2) "accel-ppp"
3) "{ \"event\": \"session-acct-start\", \"ctrl_type\": \"pppoe\", \"channel_name\": \"aa:aa:aa:aa:00:c8\", \"session_id\": \"d89da8604fc10e66\", \"called_station_id\": \"06:9d:98:10:37:7e\", \"calling_station_id\": \"aa:aa:aa:aa:00:c8\", \"name\": \"pppoe\", \"username\": \"sp-tin\", \"ip_addr\": \"192.51.0.3\", \"pppoe_sessionid\": 1, \"ctrl_ifname\": \"vethAC.7.200\", \"nas_identifier\": \"nas1\", \"qos_val\": \"1\\/16000\\/2000\" }"
```