### PR TITLE
Unify switch statements

### DIFF
--- a/accel-pppd/redis/redis.c
+++ b/accel-pppd/redis/redis.c
@@ -148,41 +148,123 @@ static void ap_redis_dequeue(struct ap_redis_t* ap_redis, redisContext* ctx)
 
 		/* event type */
 		switch (msg->event) {
-		case REDIS_EV_SES_STARTING:             jstring = json_object_new_string("session-starting");       break;
-		case REDIS_EV_SES_STARTED:              jstring = json_object_new_string("session-started");        break;
-		case REDIS_EV_SES_FINISHING:		jstring = json_object_new_string("session-finishing");      break;
-		case REDIS_EV_SES_FINISHED:             jstring = json_object_new_string("session-finished");       break;
-		case REDIS_EV_SES_AUTHORIZED:		jstring = json_object_new_string("session-authorized");     break;
-		case REDIS_EV_CTRL_STARTING:		jstring = json_object_new_string("control-starting");       break;
-		case REDIS_EV_CTRL_STARTED:             jstring = json_object_new_string("control-started");        break;
-		case REDIS_EV_CTRL_FINISHED:		jstring = json_object_new_string("control-finished");       break;
-		case REDIS_EV_SES_PRE_UP:               jstring = json_object_new_string("session-pre-up");         break;
-		case REDIS_EV_SES_ACCT_START:           jstring = json_object_new_string("session-acct-start");     break;
-		case REDIS_EV_CONFIG_RELOAD:            jstring = json_object_new_string("config-reload");          break;
-		case REDIS_EV_SES_AUTH_FAILED:          jstring = json_object_new_string("session-auth-failed");    break;
-		case REDIS_EV_SES_PRE_FINISHED:         jstring = json_object_new_string("session-pre-finished");   break;
-		case REDIS_EV_IP_CHANGED:               jstring = json_object_new_string("ip-changed");             break;
-		case REDIS_EV_SHAPER:                   jstring = json_object_new_string("shaper");                 break;
-		case REDIS_EV_MPPE_KEYS:                jstring = json_object_new_string("mppe-keys");              break;
-		case REDIS_EV_DNS:                      jstring = json_object_new_string("dns");                    break;
-		case REDIS_EV_WINS:                     jstring = json_object_new_string("wins");                   break;
-		case REDIS_EV_FORCE_INTERIM_UPDATE:     jstring = json_object_new_string("force-interim-update");   break;
-		case REDIS_EV_RADIUS_ACCESS_ACCEPT:     jstring = json_object_new_string("radius-access-accept");   break;
-		case REDIS_EV_RADIUS_COA:               jstring = json_object_new_string("coa");                    break;
-		default:                                jstring = json_object_new_string("unknown");                break;
+			case REDIS_EV_SES_STARTING:
+				jstring = json_object_new_string("session-starting");
+				break;
+
+			case REDIS_EV_SES_STARTED:
+				jstring = json_object_new_string("session-started");
+				break;
+
+			case REDIS_EV_SES_FINISHING:
+				jstring = json_object_new_string("session-finishing");
+				break;
+
+			case REDIS_EV_SES_FINISHED:
+				jstring = json_object_new_string("session-finished");
+				break;
+
+			case REDIS_EV_SES_AUTHORIZED:
+				jstring = json_object_new_string("session-authorized");
+				break;
+
+			case REDIS_EV_CTRL_STARTING:
+				jstring = json_object_new_string("control-starting");
+				break;
+
+			case REDIS_EV_CTRL_STARTED:
+				jstring = json_object_new_string("control-started");
+				break;
+
+			case REDIS_EV_CTRL_FINISHED:
+				jstring = json_object_new_string("control-finished");
+				break;
+
+			case REDIS_EV_SES_PRE_UP:
+				jstring = json_object_new_string("session-pre-up");
+				break;
+
+			case REDIS_EV_SES_ACCT_START:
+				jstring = json_object_new_string("session-acct-start");
+				break;
+
+			case REDIS_EV_CONFIG_RELOAD:
+				jstring = json_object_new_string("config-reload");
+				break;
+
+			case REDIS_EV_SES_AUTH_FAILED:
+				jstring = json_object_new_string("session-auth-failed");
+				break;
+
+			case REDIS_EV_SES_PRE_FINISHED:
+				jstring = json_object_new_string("session-pre-finished");
+				break;
+
+			case REDIS_EV_IP_CHANGED:
+				jstring = json_object_new_string("ip-changed");
+				break;
+
+			case REDIS_EV_SHAPER:
+				jstring = json_object_new_string("shaper");
+				break;
+
+			case REDIS_EV_MPPE_KEYS:
+				jstring = json_object_new_string("mppe-keys");
+				break;
+
+			case REDIS_EV_DNS:
+				jstring = json_object_new_string("dns");
+				break;
+
+			case REDIS_EV_WINS:
+				jstring = json_object_new_string("wins");
+				break;
+
+			case REDIS_EV_FORCE_INTERIM_UPDATE:
+				jstring = json_object_new_string("force-interim-update");
+				break;
+
+			case REDIS_EV_RADIUS_ACCESS_ACCEPT:
+				jstring = json_object_new_string("radius-access-accept");
+				break;
+
+			case REDIS_EV_RADIUS_COA:
+				jstring = json_object_new_string("coa");
+				break;
+
+			default:
+				jstring = json_object_new_string("unknown");
+				break;
 		}
 		json_object_object_add(jobj, "event", jstring);
 
 		/* session ctrl type */
 		switch (msg->ses_ctrl_type) {
-		case REDIS_SES_CTRL_TYPE_PPTP:    jstring = json_object_new_string("pptp");    break;
-		case REDIS_SES_CTRL_TYPE_L2TP:    jstring = json_object_new_string("l2tp");    break;
-		case REDIS_SES_CTRL_TYPE_PPPOE:   jstring = json_object_new_string("pppoe");   break;
-		case REDIS_SES_CTRL_TYPE_IPOE:    jstring = json_object_new_string("ipoe");    break;
-		case REDIS_SES_CTRL_TYPE_OPENVPN: jstring = json_object_new_string("openvpn"); break;
-		case REDIS_SES_CTRL_TYPE_SSTP:    jstring = json_object_new_string("sstp");    break;
-		default: {};
+			case REDIS_SES_CTRL_TYPE_PPTP:
+				jstring = json_object_new_string("pptp");
+				break;
+
+			case REDIS_SES_CTRL_TYPE_L2TP:
+				jstring = json_object_new_string("l2tp");
+				break;
+
+			case REDIS_SES_CTRL_TYPE_PPPOE:
+				jstring = json_object_new_string("pppoe");
+				break;
+
+			case REDIS_SES_CTRL_TYPE_IPOE:
+				jstring = json_object_new_string("ipoe");
+				break;
+
+			case REDIS_SES_CTRL_TYPE_OPENVPN:
+				jstring = json_object_new_string("openvpn");
+				break;
+
+			case REDIS_SES_CTRL_TYPE_SSTP:
+				jstring = json_object_new_string("sstp");
+				break;
 		}
+
 		json_object_object_add(jobj, "ctrl_type", jstring);
 
 		/* session channel name */
@@ -481,12 +563,10 @@ static void ap_redis_enqueue(struct ap_session *ses, const int event)
 		case REDIS_EV_WINS:
 		case REDIS_EV_FORCE_INTERIM_UPDATE:
 		case REDIS_EV_RADIUS_ACCESS_ACCEPT:
-		case REDIS_EV_RADIUS_COA: {
-			/* do nothing */
-		} break;
-		default: {
+		case REDIS_EV_RADIUS_COA:
+			break; /* do nothing */
+		default:
 			return;
-		};
 	}
 
 	struct ap_redis_msg_t* msg = mempool_alloc(ap_redis->msg_pool);
@@ -526,14 +606,29 @@ static void ap_redis_enqueue(struct ap_session *ses, const int event)
 	msg->nas_identifier = _strdup(ap_redis->nas_id);
 
 	switch(ses->ctrl->type) {
-	case CTRL_TYPE_PPTP:    msg->ses_ctrl_type = REDIS_SES_CTRL_TYPE_PPTP;    break;
-	case CTRL_TYPE_L2TP:    msg->ses_ctrl_type = REDIS_SES_CTRL_TYPE_L2TP;    break;
-	case CTRL_TYPE_PPPOE:   msg->ses_ctrl_type = REDIS_SES_CTRL_TYPE_PPPOE;   break;
-	case CTRL_TYPE_IPOE:    msg->ses_ctrl_type = REDIS_SES_CTRL_TYPE_IPOE;    break;
-	case CTRL_TYPE_OPENVPN: msg->ses_ctrl_type = REDIS_SES_CTRL_TYPE_OPENVPN; break;
-	case CTRL_TYPE_SSTP:    msg->ses_ctrl_type = REDIS_SES_CTRL_TYPE_SSTP;    break;
-	default:{
-	}
+		case CTRL_TYPE_PPTP:
+			msg->ses_ctrl_type = REDIS_SES_CTRL_TYPE_PPTP;
+			break;
+
+		case CTRL_TYPE_L2TP:
+			msg->ses_ctrl_type = REDIS_SES_CTRL_TYPE_L2TP;
+			break;
+
+		case CTRL_TYPE_PPPOE:
+			msg->ses_ctrl_type = REDIS_SES_CTRL_TYPE_PPPOE;
+			break;
+
+		case CTRL_TYPE_IPOE:
+			msg->ses_ctrl_type = REDIS_SES_CTRL_TYPE_IPOE;
+			break;
+
+		case CTRL_TYPE_OPENVPN:
+			msg->ses_ctrl_type = REDIS_SES_CTRL_TYPE_OPENVPN;
+			break;
+
+		case CTRL_TYPE_SSTP:
+			msg->ses_ctrl_type = REDIS_SES_CTRL_TYPE_SSTP;
+			break;
 	}
 
 	spin_lock(&ap_redis->msg_queue_lock);


### PR DESCRIPTION
# Purpose
This is only a cosmetic change which should not change any logic.

The formatting of the switch statements in the redis module is quite
chaotic. This commit unifies the switch statement format in the redis
module:
- Stick to a single state statement per line
- Add whitespaces after the cases to improve readability
- Remove empty default statements

# Testing
I tested this change locally simply by establishing a user session. The session establishment should touch most of the changed LoCs.

## Prerequisites 
- redis module enabled (event for publishing configured, e.g. `ev_ses_acct_start=yes`)
- `redis-cli`
- `pppd`

## Test steps
1. Start accel-ppp
2. Watch the redis channel with `redis-cli`:
    ```
    $ redis-cli
    127.0.0.1:6379> subscribe accel-ppp
    Reading messages... (press Ctrl-C to quit)
    1) "subscribe"
    2) "accel-ppp"
    3) (integer) 1
    ```

3. Create a user session with `pppd`:
    ```
     pppd pty "pppoe -I <IFACE> -T 80 -U -m 1350" \
        noccp \
        ipparam <IFACE> \
        linkname <IFACE> \
        noipdefault \
        noauth \
        default-asyncmap \
        defaultroute \
        hide-password \
        updetach \
        mtu 1350 \
        mru 1350 \
        noaccomp \
        nodeflate \
        nopcomp \
        novj \
        novjccomp \
        lcp-echo-interval 40 \
        lcp-echo-failure 3 \
        user <PPP_USER> \
        password <PPP_PASWORD>

    ```
 
 ## Expected behavior
 The session is successfully established and the configured messages are published on the redis channel.
```
$ redis-cli
127.0.0.1:6379> subscribe accel-ppp
Reading messages... (press Ctrl-C to quit)
1) "subscribe"
2) "accel-ppp"
3) (integer) 1
1) "message"
2) "accel-ppp"
3) "{ \"event\": \"session-acct-start\", \"ctrl_type\": \"pppoe\", \"channel_name\": \"aa:aa:aa:aa:00:64\", \"session_id\": 
\"d89da8604fc13970\", \"called_station_id\": \"7a:99:8f:4d:07:22\", \"calling_station_id\": \"aa:aa:aa:aa:00:64\", \"name\": 
\"pppoe\", \"username\": \"sp-tin\", \"ip_addr\": \"192.51.0.4\", \"pppoe_sessionid\": 1, \"ctrl_ifname\": \"vethAC.7.100\", 
\"nas_identifier\": \"nas1\", \"qos_val\": \"1\\/16000\\/2000\" }"
```