### PR TITLE
Add custom PPPoE tag to represent subscriber VLANs

### DIFF
--- a/accel-pppd/ctrl/pppoe/pppoe.h
+++ b/accel-pppd/ctrl/pppoe/pppoe.h
@@ -44,6 +44,7 @@
 #define MAX_PPPOE_MTU (MAX_PPPOE_PAYLOAD - 2)
 
 #define VENDOR_ADSL_FORUM 0xde9
+#define VENDOR_BISDN 0xaaaa
 
 #define SECRET_LENGTH 16
 #define COOKIE_LENGTH 24
@@ -96,6 +97,8 @@ struct pppoe_serv_t
 	int padi_cnt;
 	int padi_limit;
 	time_t last_padi_limit_warn;
+
+	struct list_head subscriber_tags_list;
 
 	int stopping:1;
 	int vlan_mon:1;

--- a/accel-pppd/include/ap_session.h
+++ b/accel-pppd/include/ap_session.h
@@ -123,6 +123,7 @@ struct ap_session
      * across events for publication on the redis bus. */
 	int conn_pppoe_sid;
 	char *filter_id;
+	uint32_t subscriber_tags;
 };
 
 struct ap_session_stat

--- a/accel-pppd/redis/redis.c
+++ b/accel-pppd/redis/redis.c
@@ -88,6 +88,7 @@ struct ap_redis_msg_t {
 	char* ctrl_ifname;
 	char* nas_identifier;
 	char* qos_val;
+	int subscriber_tags;
 };
 
 struct ap_redis_t {
@@ -228,6 +229,10 @@ static void ap_redis_dequeue(struct ap_redis_t* ap_redis, redisContext* ctx)
 		/* qos_val */
 		if (msg->qos_val)
 			json_object_object_add(jobj, "qos_val", json_object_new_string(msg->qos_val));
+
+		/* subscriber_tags */
+		if (msg->subscriber_tags)
+			json_object_object_add(jobj, "subscriber_tags", json_object_new_int(msg->subscriber_tags));
 
 		// TODO: send msg to redis instance
 		redisReply* reply;
@@ -521,6 +526,8 @@ static void ap_redis_enqueue(struct ap_session *ses, const int event)
 		msg->ctrl_ifname = _strdup(ses->ctrl->ifname);
 	if (ses->filter_id)
 		msg->qos_val = _strdup(ses->filter_id);
+	if (ses->subscriber_tags)
+		msg->subscriber_tags = ses->subscriber_tags;
 
 	msg->ip_addr = _strdup(tmp_addr);
 	msg->nas_identifier = _strdup(ap_redis->nas_id);


### PR DESCRIPTION
Adds support for processing a PPPoE tag in PADI packets with vendor specific ID 0xaaaa (VENDOR_BISDN). The payload of this tag represents the VLANs used by a subscriber, as a workaround of not working with vlan-mon/tagged interfaces in a containerized environment. Obviously, this requires that such tag is added to the PADI packets (i.e. in the SSS Endpoint).

The extracted tag information is encoded in an integer and added to the ap_session data structure. Whenever the redis module processes an internal event, the subscriber_tags fields is added to the published redis message.
