### PR TITLE
20 reconnect if redis server is miss

### DIFF
--- a/accel-pppd/redis/redis.c
+++ b/accel-pppd/redis/redis.c
@@ -264,6 +264,10 @@ static void ap_redis_dequeue(struct ap_redis_t* ap_redis, redisContext** ctx)
         					n_rounds--;
 						/* return after DEFAULT_MAX_ROUNDS */
                 		                if (!n_rounds) {
+                                                        if (*ctx) {
+                                                                redisFree(*ctx);
+                                                                *ctx = NULL;
+                                                        }
 						        return;	
 						}
                 	                } else {

--- a/accel-pppd/redis/redis.c
+++ b/accel-pppd/redis/redis.c
@@ -268,6 +268,9 @@ static void ap_redis_dequeue(struct ap_redis_t* ap_redis, redisContext** ctx)
                                                                 redisFree(*ctx);
                                                                 *ctx = NULL;
                                                         }
+
+		                                        /* delete json object */
+                 		                        json_object_put(jobj);
 						        return;	
 						}
                 	                } else {
@@ -290,6 +293,7 @@ static void ap_redis_dequeue(struct ap_redis_t* ap_redis, redisContext** ctx)
         			default: {
                                         redisFree(*ctx);
         				*ctx = NULL;
+
 		                        /* delete json object */
                  		        json_object_put(jobj);
         		        } return;


### PR DESCRIPTION
**Problem description:**

- Affected module: **redis**
- Function redisConnect() may block infinitely if the specified transport address [host:port] is unreachable

**Goal:**

- Replace function redisConnect() with redisConnectWithTimeout()
- Add parameter :timeout to configuration settings for module redis

**Changes:**

- As described above