### PR TITLE
Spin unlock in ap redis dequeue

### DIFF
--- a/accel-pppd/redis/redis.c
+++ b/accel-pppd/redis/redis.c
@@ -264,6 +264,10 @@ static void ap_redis_dequeue(struct ap_redis_t* ap_redis, redisContext** ctx)
         					n_rounds--;
 						/* return after DEFAULT_MAX_ROUNDS */
                 		                if (!n_rounds) {
+                                                        if (*ctx) {
+                                                                redisFree(*ctx);
+                                                                *ctx = NULL;
+                                                        }
 						        return;	
 						}
                 	                } else {

--- a/accel-pppd/redis/redis.c
+++ b/accel-pppd/redis/redis.c
@@ -240,7 +240,7 @@ static int ap_redis_dequeue(struct ap_redis_t* ap_redis, redisContext** ctx)
 		if (msg->subscriber_tags)
 			json_object_object_add(jobj, "subscriber_tags", json_object_new_int(msg->subscriber_tags));
 
-		/* sent message to redis */
+		/* send message to redis */
 		unsigned int msg_sent = 0;
 		while (!msg_sent) {
 

--- a/accel-pppd/redis/redis.c
+++ b/accel-pppd/redis/redis.c
@@ -268,6 +268,9 @@ static void ap_redis_dequeue(struct ap_redis_t* ap_redis, redisContext** ctx)
                                                                 redisFree(*ctx);
                                                                 *ctx = NULL;
                                                         }
+
+		                                        /* delete json object */
+                 		                        json_object_put(jobj);
 						        return;	
 						}
                 	                } else {
@@ -290,6 +293,7 @@ static void ap_redis_dequeue(struct ap_redis_t* ap_redis, redisContext** ctx)
         			default: {
                                         redisFree(*ctx);
         				*ctx = NULL;
+
 		                        /* delete json object */
                  		        json_object_put(jobj);
         		        } return;


### PR DESCRIPTION
**Problem description:**

- Affected module: **redis**
- We return from function ap_redis_dequeue() if either
    - all messages were sent successfully or ...
    - function redisConnectWithTimeout() failed or ...
    - function redisCommand() failed.
- In cases 2 and 3 we are not properly unlocking the spinlock obtained when entering function ap_redis_dequeue()

**Goal:**

- We have to unlock the message queue before returning.

**Changes:**

- Altered integer return value to function ap_redis_dequeue()
- Return value 0 indicates success
- Return value -1 indicates error occurred
- Function ap_redis_thread() reenters ap_redis_dequeue() while return value equals -1